### PR TITLE
Add url field to library.properties

### DIFF
--- a/TB6560DRIVER/library.properties
+++ b/TB6560DRIVER/library.properties
@@ -5,4 +5,4 @@ maintainer=Thomas Dose
 sentence=TB6560DRIVER (CNC MOTOR DRIVER MODULE)
 paragraph=This library allows you control stepper motor using Arduino and TB6560
 category=Uncategorized
-
+url=https://github.com/Thoby22/ArduinoTB6560


### PR DESCRIPTION
When the url field is missing from library.properties:

- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- The library's examples are not shown under the File > Examples menu
- Library Manager index inclusion request is blocked.

With older IDE versions:
- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format